### PR TITLE
解答設定画面のUIと関連処理を実装

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,9 @@ import store from './stores'
 import UserMain from './features/users/components/Main'
 import SignUpPage from './features/users/components/SignUpPage'
 import Timer from './features/stepq/components/Timer'
+import Question from './features/stepq/components/Question'
+import TrialSetting from './features/stepq/components/TrialSetting'
+import StepqMain from './features/stepq/components/Main'
 
 function App() {
 
@@ -18,6 +21,9 @@ function App() {
           <Route path="/signin" element={<SignInPage />} />
           <Route path="/user" element={<UserMain />} />
           <Route path="/signup" element={<SignUpPage />} />
+          <Route path='/q' element={<Question />} />
+          <Route path='/setting_' element={<TrialSetting />} />
+          <Route path='/stepq/:id' element={<StepqMain />} />
         </Routes>
       </BrowserRouter>
       </Provider>

--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import type { QGroup, TrialPostData } from '../type';
+
+const ENDPOINT_URL = 'http://localhost:3002';
+const endpointUser = `${ENDPOINT_URL}/user`;
+const endpointTrial = `${ENDPOINT_URL}/trial`;
+const endpointQgroup = `${ENDPOINT_URL}/qgroup`;
+
+const stepqApi = {
+    async generateTrial(qgroupKeyword: string, passphrase: string, userId: string): Promise<string> {
+        const qgroups = (await axios.get<QGroup[]>(`${endpointQgroup}`)).data;
+        const qgroup = qgroups.find((data: QGroup) => data.title === qgroupKeyword );
+        if (qgroup == undefined || passphrase != qgroup.passphrase) {
+            return 'failure';
+        }
+
+        const trialData: TrialPostData = {
+            qgroupId: qgroup.id,
+            userId: userId,
+            startTime: dateToISOStringSeconds(new Date())
+        };
+        const res = await axios.post(`${endpointTrial}`, trialData);
+        console.log(res);
+        return res.status == 201 ? res.data.id : 'failure2';
+    }
+};
+
+const dateToISOStringSeconds = (date: Date): string => {
+    const _ = new Date(date);
+    _.setMilliseconds(0);
+    return _.toISOString().replace(/\.\d{3}Z$/, 'Z');
+};
+
+export default stepqApi;

--- a/client/src/features/stepq/components/Main.tsx
+++ b/client/src/features/stepq/components/Main.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useSelector, type RootState } from "../../../stores";
+import Timer from "./Timer";
+import Question from "./Question";
+
+const Main: React.FC = () => {
+    const urlParam = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const userId = useSelector((state: RootState) => state.user.id);
+
+    useEffect(() => {   
+        console.log(`redux: ${userId}`);
+        // reduxの管理が正しくできていない → sessionStorageなどで正しく永続化する必要あり
+        // 正しく永続化できたら
+        // if (trial.userId != userId) { navigate('/error'); } を追加する
+    }, []);
+
+    return (
+        <div>
+            <Timer />
+            <Question />
+        </div>
+    );
+};
+
+export default Main;

--- a/client/src/features/stepq/components/Question.tsx
+++ b/client/src/features/stepq/components/Question.tsx
@@ -1,4 +1,12 @@
+import { useState } from "react";
+
 const Question: React.FC = () => {
+    const [answer, setAnswer] = useState('');
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setAnswer(e.target.value);
+    };
+
     return (
         <div className="w-full max-w-md bg-white shadow-md p-4 space-y-6">
             <div>
@@ -12,6 +20,7 @@ const Question: React.FC = () => {
                     type="text" 
                     id="answer" name="answer"
                     placeholder="answer"
+                    onChange={handleChange}
                     className="w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50"
                 />
             </form>

--- a/client/src/features/stepq/components/TrialSetting.tsx
+++ b/client/src/features/stepq/components/TrialSetting.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactEventHandler } from "react";
 import stepqApi from "../api/stepqApi";
-import { useSelector } from "react-redux";
-import type { RootState } from "../../../stores";
+import { useSelector, type RootState } from "../../../stores";
+import { useNavigate } from "react-router-dom";
 
 const TrialSetting: React.FC = () => {
 
@@ -10,6 +10,7 @@ const TrialSetting: React.FC = () => {
         passphrase: ''
     });
     const userId = useSelector((state: RootState) => state.user.id);
+    const navigate = useNavigate();
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target;
@@ -20,6 +21,7 @@ const TrialSetting: React.FC = () => {
         console.log(userId);
         const str = await stepqApi.generateTrial(form.keyword, form.passphrase, userId);
         console.log(str);
+        navigate(`/stepq/${str}`);
     };
 
     return (

--- a/client/src/features/stepq/components/TrialSetting.tsx
+++ b/client/src/features/stepq/components/TrialSetting.tsx
@@ -1,0 +1,76 @@
+import { useState, type ReactEventHandler } from "react";
+import stepqApi from "../api/stepqApi";
+import { useSelector } from "react-redux";
+import type { RootState } from "../../../stores";
+
+const TrialSetting: React.FC = () => {
+
+    const [form, setForm] = useState({
+        keyword: '',
+        passphrase: ''
+    });
+    const userId = useSelector((state: RootState) => state.user.id);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        setForm((prev) => ({ ...prev, [name]: value }));
+    };
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        console.log(userId);
+        const str = await stepqApi.generateTrial(form.keyword, form.passphrase, userId);
+        console.log(str);
+    };
+
+    return (
+        <div className="w-full max-w-md bg-white shadow-md rounded-lg p-8 space-y-6" onSubmit={handleSubmit}>
+          <div>
+            <h2 className="text-center text-2xl font-bold text-gray-800">
+              Step Quiz
+            </h2>
+            <p className="mt-1 text-center text-sm text-gray-500">
+              出題者から指定された情報を入力してください
+            </p>
+          </div>
+          <form className="space-y-4" >
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                keyword
+              </label>
+              <input
+                type="text"
+                id="keyword"
+                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-400 focus:outline-none text-gray-800"
+                placeholder="keyword"
+                name='keyword'
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                passphrase
+              </label>
+              <input
+                type="password"
+                id="passphrase"
+                className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-400 focus:outline-none text-gray-800"
+                placeholder="********"
+                name='passphrase'
+                onChange={handleChange}
+                required
+              />
+            </div>
+    
+            <button
+              type="submit"
+              className="w-full bg-indigo-600 text-white py-2 rounded-md hover:bg-indigo-700 transition duration-200"
+            >
+              Start
+            </button>
+          </form>
+        </div>
+      );
+};
+
+export default TrialSetting;

--- a/client/src/features/stepq/type.ts
+++ b/client/src/features/stepq/type.ts
@@ -1,0 +1,12 @@
+export type TrialPostData = {
+    qgroupId: string;
+    userId: string;
+    startTime: string;
+};
+
+export type QGroup = {
+    id: string;
+    title: string;
+    passphrase: string;
+    timeLimit: number;
+};


### PR DESCRIPTION
## 概要
解答設定画面(TrialSetting.tsx)に関連するUI・処理を実装した

## 変更点
- TrialSetting.tsx
  - UIを設計・実装した
  - Formの変更・送信ロジックを追加した
    - Form送信後に解答画面に遷移するようにした
  - Questionコンポーネントにおいて、解答の入力を反映するロジックを追加した
- Trialデータの生成操作を行うAPIを作成した

### 本PRのスコープ外のタスク
- 解答画面についてはモックで、後ほど追加で詳細実装する必要がある
  - `/stepq/:id`にアクセスした際にセッションのログインユーザーと一致しているかを確認する
  - 解答画面での解答送信・記録ロジックについて検討する
- エラー画面を作成してエラー・例外発生時にアクセスする

## 動作確認

### 試したこと
- Routingを追加してnpm run devでコンポーネントにアクセス
  - Qgroupをdb.jsonに手動で追加してデータを参照する 

### 確認したこと
- `/signin`→`/setting_`→`/stepq/:id`の画面遷移が正常に行われている