### PR TITLE
Feature/stepq/question fetch

### DIFF
--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -37,6 +37,13 @@ const stepqApi = {
         })).data;
         if (question.length != 1) { return undefined; }
         return question[0];
+    },
+    async fetchTrial(id: string): Promise<Trial | undefined> {
+        const trial = (await axios.get<Trial[]>(endpointTrial, {
+            params: { id: id }
+        })).data;
+        if (trial.length != 1) { return undefined; }
+        return trial[0];
     }
 };
 

--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import type { QGroup, Trial, TrialPostData } from '../type';
+import { ENDPOINT_URL } from '../../../references/util';
 
-const ENDPOINT_URL = 'http://localhost:3002';
 const endpointUser = `${ENDPOINT_URL}/user`;
 const endpointTrial = `${ENDPOINT_URL}/trial`;
 const endpointQgroup = `${ENDPOINT_URL}/qgroup`;

--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
-import type { QGroup, Trial, TrialPostData } from '../type';
+import type { QGroup, Question, Trial, TrialPostData } from '../type';
 import { ENDPOINT_URL } from '../../../references/util';
 
 const endpointUser = `${ENDPOINT_URL}/user`;
 const endpointTrial = `${ENDPOINT_URL}/trial`;
 const endpointQgroup = `${ENDPOINT_URL}/qgroup`;
+const endpointQuestion = `${ENDPOINT_URL}/question`;
 
 const stepqApi = {
     async generateTrial(qgroupKeyword: string, passphrase: string, userId: string): Promise<string> {
@@ -29,6 +30,13 @@ const stepqApi = {
         const res = await axios.post(`${endpointTrial}`, trialData);
         console.log(res);
         return res.status == 201 ? res.data.id : '';
+    },
+    async fetchQuestion(qgroupId: string, index: number): Promise<Question | undefined> {
+        const question = (await axios.get<Question[]>(endpointQuestion, {
+            params: { qgroupId: qgroupId, index: index }
+        })).data;
+        if (question.length != 1) { return undefined; }
+        return question[0];
     }
 };
 

--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -23,6 +23,7 @@ const stepqApi = {
         const trialData: TrialPostData = {
             qgroupId: qgroup.id,
             userId: userId,
+            index: 1,
             startTime: dateToISOStringSeconds(new Date())
         };
         const res = await axios.post(`${endpointTrial}`, trialData);

--- a/client/src/features/stepq/components/Main.tsx
+++ b/client/src/features/stepq/components/Main.tsx
@@ -12,16 +12,7 @@ const Main: React.FC = () => {
     const userId = useSelector((state: RootState) => state.user.id);
 
     const [trial, setTrial] = useState<Trial>();
-
-    // 仮データ
     const [index, setIndex] = useState(0);
-    const _t = {
-      id: "c4b7",
-      qgroupId: "0001",
-      userId: "0000",
-      startTime: "2025-08-09T02:04:25Z",
-      index: 1
-    }
 
     useEffect(() => {
         // reduxの管理が正しくできていない → sessionStorageなどで正しく永続化する必要あり

--- a/client/src/features/stepq/components/Main.tsx
+++ b/client/src/features/stepq/components/Main.tsx
@@ -3,11 +3,15 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useSelector, type RootState } from "../../../stores";
 import Timer from "./Timer";
 import Question from "./Question";
+import type { Trial } from "../type";
+import stepqApi from "../api/stepqApi";
 
 const Main: React.FC = () => {
     const urlParam = useParams<{ id: string }>();
     const navigate = useNavigate();
     const userId = useSelector((state: RootState) => state.user.id);
+
+    const [trial, setTrial] = useState<Trial>();
 
     // 仮データ
     const [index, setIndex] = useState(0);
@@ -23,13 +27,27 @@ const Main: React.FC = () => {
         // reduxの管理が正しくできていない → sessionStorageなどで正しく永続化する必要あり
         // 正しく永続化できたら
         // if (trial.userId != userId) { navigate('/error'); } を追加する
-        
+        const awake = async () => {
+            if (!urlParam.id) {
+                return;
+            }
+            const _t = await stepqApi.fetchTrial(urlParam.id);
+            if (!_t) {
+                return; 
+            }
+            setTrial(_t);
+            setIndex(_t ? _t.index : 0 );
+        };
+        awake();
     }, []);
 
+    if (!trial) {
+        return <p>エラー発生！</p>
+    }
     return (
         <div>
             <Timer />
-            <Question trial={_t} index={1} setIndex={setIndex} />
+            <Question trial={trial} index={index} setIndex={setIndex} />
         </div>
     );
 };

--- a/client/src/features/stepq/components/Main.tsx
+++ b/client/src/features/stepq/components/Main.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useSelector, type RootState } from "../../../stores";
 import Timer from "./Timer";
@@ -9,17 +9,27 @@ const Main: React.FC = () => {
     const navigate = useNavigate();
     const userId = useSelector((state: RootState) => state.user.id);
 
-    useEffect(() => {   
-        console.log(`redux: ${userId}`);
+    // 仮データ
+    const [index, setIndex] = useState(0);
+    const _t = {
+      id: "c4b7",
+      qgroupId: "0001",
+      userId: "0000",
+      startTime: "2025-08-09T02:04:25Z",
+      index: 1
+    }
+
+    useEffect(() => {
         // reduxの管理が正しくできていない → sessionStorageなどで正しく永続化する必要あり
         // 正しく永続化できたら
         // if (trial.userId != userId) { navigate('/error'); } を追加する
+        
     }, []);
 
     return (
         <div>
             <Timer />
-            <Question />
+            <Question trial={_t} index={1} setIndex={setIndex} />
         </div>
     );
 };

--- a/client/src/features/stepq/components/Question.tsx
+++ b/client/src/features/stepq/components/Question.tsx
@@ -14,12 +14,12 @@ const QuestionComponent: React.FC<Props> = ({ trial, index, setIndex }) => {
     const [question, setQuestion] = useState<Question>();
 
     useEffect(() => {
-        const commApi = async () => {
+        const awake = async () => {
             const q = await stepqApi.fetchQuestion(trial.qgroupId, index);
             setQuestion(q);
         };
-        commApi();
-    });
+        awake();
+    }, [index]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setAnswer(e.target.value);

--- a/client/src/features/stepq/components/Question.tsx
+++ b/client/src/features/stepq/components/Question.tsx
@@ -1,19 +1,40 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import type { Question, Trial } from "../type";
+import axios from "axios";
+import stepqApi from "../api/stepqApi";
 
-const Question: React.FC = () => {
+type Props = {
+    trial: Trial;
+    index: number;
+    setIndex: React.Dispatch<React.SetStateAction<number>>;
+};
+
+const QuestionComponent: React.FC<Props> = ({ trial, index, setIndex }) => {
     const [answer, setAnswer] = useState('');
+    const [question, setQuestion] = useState<Question>();
+
+    useEffect(() => {
+        const commApi = async () => {
+            const q = await stepqApi.fetchQuestion(trial.qgroupId, index);
+            setQuestion(q);
+        };
+        commApi();
+    });
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setAnswer(e.target.value);
     };
 
+    if (!question) {
+        return <p>エラー発生</p>;
+    }
     return (
         <div className="w-full max-w-md bg-white shadow-md p-4 space-y-6">
             <div>
-                第 <span className="font-semibold text-lg">1</span> 問
+                第 <span className="font-semibold text-lg">{index}</span> 問
             </div>
             <div className="shadow-sm rounded-sm p-2 text-left border-l-2 border-cyan-300">
-                ヨルシカの楽曲『左右盲』で、歌詞の「心をわすれる」の表記はまさに心を忘れた何？
+                {question.questionText}
             </div>
             <form>
                 <input 
@@ -28,4 +49,4 @@ const Question: React.FC = () => {
     );
 };
 
-export default Question;
+export default QuestionComponent;

--- a/client/src/features/stepq/type.ts
+++ b/client/src/features/stepq/type.ts
@@ -1,6 +1,7 @@
 export type TrialPostData = {
     qgroupId: string;
     userId: string;
+    index: number;
     startTime: string;
 };
 
@@ -16,4 +17,22 @@ export type QGroup = {
     title: string;
     passphrase: string;
     timeLimit: number;
+};
+
+export type Question = {
+    id: string;
+    qgroupId: string;
+    index: number;
+    questionText: string;
+    correctAnswer: string;
+    description: string;
+};
+
+export type Answer = {
+    id: string;
+    trialId: string;
+    questionId: string;
+    answer: string;
+    score: number;
+    memo: string;
 };

--- a/client/src/features/stepq/type.ts
+++ b/client/src/features/stepq/type.ts
@@ -9,6 +9,7 @@ export type Trial = {
     id: string;
     qgroupId: string;
     userId: string;
+    index: number;
     startTime: string;
 };
 

--- a/client/src/features/users/api/userApi.ts
+++ b/client/src/features/users/api/userApi.ts
@@ -1,12 +1,13 @@
 import axios from "axios";
 import type { SignInData, SignInResponse, User, SignUpData } from "../type";
+import { ENDPOINT_URL } from "../../../references/util";
 
-const ENDPOINT_URL = 'http://localhost:3002/user'; // TODO: User処理のURLを追記する
+const endpoint = `${ENDPOINT_URL}/user`; // TODO: User処理のURLを追記する
 
 const userApi = {
     async signIn(signInData: SignInData): Promise<SignInResponse> {
 
-            const users = (await axios.get<User[]>(`${ENDPOINT_URL}`)).data;
+            const users = (await axios.get<User[]>(`${endpoint}`)).data;
             const user = users.find((data: User) => data.email == signInData.email);
             if (user == undefined || user.password != signInData.password) {
                 return { isAuthenticated: false, id: "" };
@@ -15,11 +16,11 @@ const userApi = {
             return { isAuthenticated: true, id: user.id };
     },
     async signUp(signUpData: SignUpData): Promise<boolean> {
-            const res = await axios.post(`${ENDPOINT_URL}`, signUpData);
+            const res = await axios.post(`${endpoint}`, signUpData);
             return (res.statusText == 'OK');    // post処理が正しく行われた場合にtrueが返される
     },
     async getUserInfo(id: string): Promise<User | undefined> {
-            const users = (await axios.get<User[]>(`${ENDPOINT_URL}`)).data;
+            const users = (await axios.get<User[]>(`${endpoint}`)).data;
             return users.find((data: User) => data.id == id);
     }
 };

--- a/client/src/references/util.ts
+++ b/client/src/references/util.ts
@@ -1,0 +1,1 @@
+export const ENDPOINT_URL = 'http://localhost:3002';


### PR DESCRIPTION
## 概要
解答画面で問題をデータベースから取得する

## 変更点
- QuestionComponentのPropを追加
- 問題文やインデックスをAPIから取得するように変更
- MainからQuestionに渡すようにデータフローを変更

### As is
- Questionコンポーネントについてデータがベタ打ち
- Stepqのメイン画面についてUI部分だけが完成

### To be
- Questionのインデックスと問題文をAPIから取得して表示する
- QuestionMainからQuestionの情報を与える

### 本PRのスコープ外のタスク
- 解答を送信する処理を実装する

## 動作確認

### 試したこと
- client直下でnpm run devを実行し、http://localhost:5173/ にアクセス
- ログインから解答画面まで遷移するように操作

### 確認したこと
- /stepq/:idでデータが正しく表示されている