### PR TITLE
解答Formをsubmitした後に次の問題に遷移する

### DIFF
--- a/client/src/features/stepq/components/Question.tsx
+++ b/client/src/features/stepq/components/Question.tsx
@@ -27,6 +27,7 @@ const QuestionComponent: React.FC<Props> = ({ trial, index, setIndex }) => {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+        setAnswer("");
         setIndex(prev => prev + 1);
     };
 
@@ -46,6 +47,7 @@ const QuestionComponent: React.FC<Props> = ({ trial, index, setIndex }) => {
                     type="text" 
                     id="answer" name="answer"
                     placeholder="answer"
+                    value={answer}
                     onChange={handleChange}
                     className="w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50"
                 />


### PR DESCRIPTION
## 概要
解答後、次の問題に遷移するように変更

## 変更点
- QuestionComponentのPropを追加
- 問題文やインデックスをAPIから取得するように変更
- MainからQuestionに渡すようにデータフローを変更

### As is
- 解答欄でEnter押下しても特に反応が無い

### To be
- 解答欄でEnter押下することで
  - 次の問題に遷移する
  - 解答欄がリセットされる

### 本PRのスコープ外のタスク
- 解答をサーバー側に送信する処理を実装する
- 最終問題の扱いについて

## 動作確認

### 試したこと
- client直下でnpm run devを実行し、http://localhost:5173/ にアクセス
- ログインから解答画面まで遷移するように操作
- 解答Formをsubmit

### 確認したこと
- /stepq/:idでデータが正しく表示されている
- 解答欄でsubmit後、次の問題に遷移する
- タイマーがsubmitに干渉せず、独立して動作している
  - 処理を追加することで不具合が出る可能性あり