### PR TITLE
StepQ: 解答送信機能の実装

### DIFF
--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -6,6 +6,7 @@ const endpointUser = `${ENDPOINT_URL}/user`;
 const endpointTrial = `${ENDPOINT_URL}/trial`;
 const endpointQgroup = `${ENDPOINT_URL}/qgroup`;
 const endpointQuestion = `${ENDPOINT_URL}/question`;
+const endpointAnswer = `${ENDPOINT_URL}/answer`;
 
 const stepqApi = {
     async generateTrial(qgroupKeyword: string, passphrase: string, userId: string): Promise<string> {
@@ -44,6 +45,17 @@ const stepqApi = {
         })).data;
         if (trial.length != 1) { return undefined; }
         return trial[0];
+    },
+    async postAnswer(answerText: string, trialId: string, questionId: string): Promise<boolean> {
+        const answerData = {
+            trialId: trialId,
+            questionId: questionId,
+            answer: answerText,
+            score: 0,
+            memo: ""
+        };
+        const res = await axios.post(endpointAnswer, answerData);
+        return res.status == 201;
     }
 };
 

--- a/client/src/features/stepq/components/Question.tsx
+++ b/client/src/features/stepq/components/Question.tsx
@@ -31,7 +31,7 @@ const QuestionComponent: React.FC<Props> = ({ trial, index, setIndex }) => {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        stepqApi.postAnswer(answer, trial.id, question.id);
+        await stepqApi.postAnswer(answer, trial.id, question.id);
         setAnswer("");
         setIndex(prev => prev + 1);
     };

--- a/client/src/features/stepq/components/Question.tsx
+++ b/client/src/features/stepq/components/Question.tsx
@@ -25,15 +25,17 @@ const QuestionComponent: React.FC<Props> = ({ trial, index, setIndex }) => {
         setAnswer(e.target.value);
     };
 
+    if (!question) {
+        return <p>エラー発生</p>;
+    }
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+        stepqApi.postAnswer(answer, trial.id, question.id);
         setAnswer("");
         setIndex(prev => prev + 1);
     };
 
-    if (!question) {
-        return <p>エラー発生</p>;
-    }
     return (
         <div className="w-full max-w-md bg-white shadow-md p-4 space-y-6">
             <div>


### PR DESCRIPTION
## 概要
解答をバックエンドに送信する

## 変更点
- StepQにおいて、解答をバックエンド側に送信する機能を追加した

### As is
- 次の問題に遷移する際に、入力した解答は捨てられる

### To be
- 入力したデータをバックエンド側に渡すように変更
  - モックのjson-serverにおいてはpostによって保存するようになっている

### 本PRのスコープ外のタスク
- バックエンド側における受け取った解答データの処理の実装

## 動作確認

### 試したこと
- StepQの解答フローをログインから実施した

### 確認したこと
- 入力したデータがモックサーバーにpostされている
