### PR TITLE
StepQ: タイマーの表示形式を変更

### DIFF
--- a/client/src/features/stepq/components/Timer.tsx
+++ b/client/src/features/stepq/components/Timer.tsx
@@ -13,7 +13,7 @@ const Timer: React.FC = () => {
         const totalSeconds = Math.floor(time_100ms / 10);
         const minutes = Math.floor(totalSeconds / 60);
         const seconds = totalSeconds % 60;
-        const deciSeconds = elapsed_100ms % 10;
+        const deciSeconds = time_100ms % 10;
 
         const paddedMinutes = String(minutes).padStart(2, '0');
         const paddedSeconds = String(seconds).padStart(2, '0');
@@ -50,7 +50,7 @@ const Timer: React.FC = () => {
 
 
     // 表示用の残り秒数
-    const displaySeconds = formatRemainingTime(Math.max(0, timeLimit - Math.floor(elapsed_100ms)));
+    const displaySeconds = formatRemainingTime(Math.max(0, timeLimit - elapsed_100ms));
 
     return (
         <div className="w-full max-w-md flex justify-center mb-3">


### PR DESCRIPTION
## 概要
解答画面のタイマーの表示形式を変更した

## 変更点

### As is
- StepQのタイマーに経過時間が100ms単位で表示される

### To be
- StepQのタイマーについて、残り時間を表示する
- 表示形式をmm:ss.dに変更する

### 本PRのスコープ外のタスク
- 残り時間が0になった時の処理

## 動作確認

### 試したこと
- StepQの解答フローをログインから実施した

### 確認したこと
- StepQのタイマーがカウントダウンになっている
- 表示形式がmm:ss.dになっている
