### PR TITLE
解答終了画面の追加

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,10 +5,9 @@ import { Provider } from 'react-redux'
 import store from './stores'
 import UserMain from './features/users/components/Main'
 import SignUpPage from './features/users/components/SignUpPage'
-import Timer from './features/stepq/components/Timer'
-import Question from './features/stepq/components/Question'
 import TrialSetting from './features/stepq/components/TrialSetting'
 import StepqMain from './features/stepq/components/Main'
+import QuestionEnd from './features/stepq/components/QuestionEnd'
 
 function App() {
 
@@ -21,9 +20,9 @@ function App() {
           <Route path="/signin" element={<SignInPage />} />
           <Route path="/user" element={<UserMain />} />
           <Route path="/signup" element={<SignUpPage />} />
-          <Route path='/q' element={<Question />} />
           <Route path='/setting_' element={<TrialSetting />} />
           <Route path='/stepq/:id' element={<StepqMain />} />
+          <Route path='/stepq/end' element={<QuestionEnd />} />
         </Routes>
       </BrowserRouter>
       </Provider>

--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -38,6 +38,13 @@ const stepqApi = {
         if (question.length != 1) { return undefined; }
         return question[0];
     },
+    async fetchQuestionGroup(qgroupId: string): Promise<QGroup | undefined> {
+        const questionGroups = (await axios.get<QGroup[]>(endpointQgroup, {
+            params: { qgroupId: qgroupId }
+        })).data;
+        if (questionGroups.length != 1) { return undefined; }
+        return questionGroups[0];
+    },
     async fetchTrial(id: string): Promise<Trial | undefined> {
         const trial = (await axios.get<Trial[]>(endpointTrial, {
             params: { id: id }

--- a/client/src/features/stepq/components/Question.tsx
+++ b/client/src/features/stepq/components/Question.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { Question, Trial } from "../type";
-import axios from "axios";
 import stepqApi from "../api/stepqApi";
+import { useNavigate } from "react-router-dom";
 
 type Props = {
     trial: Trial;
@@ -12,12 +12,21 @@ type Props = {
 const QuestionComponent: React.FC<Props> = ({ trial, index, setIndex }) => {
     const [answer, setAnswer] = useState('');
     const [question, setQuestion] = useState<Question>();
+    const navigate = useNavigate();
 
     useEffect(() => {
+        const checkQuestionOrdered = async () => {
+            const nQuestions = (await stepqApi.fetchQuestionGroup(trial.qgroupId))?.nQuestions;
+            if (nQuestions == undefined) { return; }
+            if (index == nQuestions + 1) {
+                navigate("/stepq/end");
+            }
+        };
         const awake = async () => {
             const q = await stepqApi.fetchQuestion(trial.qgroupId, index);
             setQuestion(q);
         };
+        checkQuestionOrdered();
         awake();
     }, [index]);
 

--- a/client/src/features/stepq/components/QuestionEnd.tsx
+++ b/client/src/features/stepq/components/QuestionEnd.tsx
@@ -1,0 +1,12 @@
+const QuestionEnd: React.FC = () => {
+    return (
+        <div className="w-full max-w-md bg-white shadow-md p-4 space-y-6">
+            <div>
+                全問の解答を正常に受け付けました。<br />
+                再度解答することはできません。
+            </div>
+        </div>
+    );
+};
+
+export default QuestionEnd;

--- a/client/src/features/stepq/type.ts
+++ b/client/src/features/stepq/type.ts
@@ -17,6 +17,7 @@ export type QGroup = {
     id: string;
     title: string;
     passphrase: string;
+    nQuestions: number;
     timeLimit: number;
 };
 


### PR DESCRIPTION
## 概要
全問解答時に、解答終了画面に遷移するように変更

## 変更点

### As is
- 全問題を解答した後、簡易のエラー画面に遷移してしまう
  - 全問題終了後も、本来はない次の問題を取ろうとしてしまうため
 
### To be
- 全問題解答後、解答完了通知画面を遷移する
  - 解答完了通知画面は全問題を解答した場合に現状限定する

### 本PRのスコープ外のタスク
- 時間切れやエラー時の処理についての検討
- 各種データフェッチの例外処理を明示的に書き直す

## 動作確認

### 試したこと
- 解答フローを一通り流して確認する

### 確認したこと
- 全問解答終了後、解答完了通知画面に遷移すること