### PR TITLE
ユーザー検索時に全データが表示されてしまう不具合修正

### DIFF
--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -92,7 +92,7 @@ const stepqApi = {
                     qgroupId: qgroupId,
                     userId: userId
                 }
-            })).data[0].id
+            })).data[0].id;
         } else {
             id = (await axios.get<Question[]>(endpointQuestion, {
                 params: {
@@ -101,7 +101,7 @@ const stepqApi = {
                 }
             })).data[0].id;
         }
-        const propertyName = `${unit}Id`
+        const propertyName = unit == 'user' ? 'trialId' : 'questionId';
         const answers = (await axios.get<Answer[]>(endpointAnswer, {
             params: {
                 qgroupId: qgroupId,


### PR DESCRIPTION
## 概要
ユーザー検索時に全データが表示されてしまう不具合の修正

## 変更点

### As is
- ユーザーネームで検索した時
  - userによらず全てのanswerデータが表示されてしまう

#### 原因
answerを取得する際に、propertyNameがuserIdになっていたため。 \
複数のQgroupがヒットしてしまう可能性があるため、本来はtrialIdで絞り込みをかける必要があった。
 
### To be
- ユーザーネームで絞り込む場合についても、該当ユーザーの回答のみが表示される

### 本PRのスコープ外のタスク

## 動作確認

### 試したこと
- 複数ユーザーで回答フローを実施
- 採点画面でユーザー検索して解答を表示させた

### 確認したこと
- ユーザーネームで絞り込む場合についても、該当ユーザーの回答のみが表示される
