### PR TITLE
採点時の保存機能の実装

### DIFF
--- a/client/src/features/stepq/api/stepqApi.ts
+++ b/client/src/features/stepq/api/stepqApi.ts
@@ -118,6 +118,10 @@ const stepqApi = {
             params: { id: trial.userId }
         })).data[0];
         return user;
+    },
+    async updateAnswerScored(answer: Answer): Promise<boolean> {
+        const res = await axios.put(`${endpointAnswer}/${answer.id}`, answer);
+        return res.status == 200;
     }
 };
 

--- a/client/src/features/stepq/components/ScoringPage.tsx
+++ b/client/src/features/stepq/components/ScoringPage.tsx
@@ -8,6 +8,7 @@ import SelectHeader from "./SelectHeader";
 import ScoringSheet from "./ScoringSheet";
 import type { User } from "../../users/type";
 import LiquidGlassButton from "./exampleButton";
+import LiquidGlass from "../../../fundamentalComponents/LiquidGlass";
 
 
 const ScoringPage = () => {
@@ -43,6 +44,12 @@ const ScoringPage = () => {
         return formattedAnswers;
     };
 
+    const savedAnswersScored = async () => {
+        for (const formattedAnswer of formattedAnswers) {
+            await stepqApi.updateAnswerScored(formattedAnswer.answer);
+        }
+    };
+
     useEffect(() => {
         const f = async () => {
             const formatted = await formatAnswerForScoring(answers);
@@ -69,9 +76,9 @@ return (
         </div>
 
         {/* 保存ボタンも中央に */}
-        <LiquidGlassButton colorScheme="purple">
+        <LiquidGlass as="button" colorScheme="purple" onClick={async () => await savedAnswersScored()}>
             保存する
-        </LiquidGlassButton>
+        </LiquidGlass>
     </div>
 );
 };


### PR DESCRIPTION
## 概要
採点結果を保存できるようにする

## 変更点

### As is
- 採点画面で採点ボタンを押しても、更新すると未採点状態になってしまう
 
### To be
- 保存ボタンを押すことで、採点が保存される
  - answerのscore, scoringStatusが保存される
  - 保存してから採点画面を再度開いた時に
    - 採点ボタンが前の採点状態で色がついた状態になる
    - 合計スコア・正解率の数について、前回までの採点状況を反映する

### 本PRのスコープ外のタスク
- 採点状況が最終版かどうかの判定
  - 最終版でない時に結果確認できないようにする必要がある

## 動作確認

### 試したこと
- 採点画面を開いて検索して採点する
- 別条件で検索する

### 確認したこと
- 別条件で検索した際に、その前で採点結果が反映されている
